### PR TITLE
Update SC list and add links for SCAM25 webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,16 +35,16 @@
 	    	The aim of the International  Conference on Source Code Analysis & Manipulation (SCAM) is to bring together researchers and practitioners working on theory, techniques and applications which concern analysis and/or manipulation of the source code of computer systems. While much attention in the wider software engineering community is properly directed towards other aspects of systems development and evolution, such as specification, design and requirements engineering, it is the source code that contains the only precise description of the behaviour of the system. The analysis and manipulation of source code thus remains a pressing concern.
 	    </p>
 	    <p>
-	    	<a href="http://www.ieee-scam.org/2023">SCAM 2023</a> has just passed and we are now looking forward to <a href="https://conf.researchr.org/home/scam-2024">SCAM 2024</a>.
+	    	<a href="https://conf.researchr.org/home/scam-2024">SCAM 2024</a> has just passed and we are now looking forward to <a href="https://conf.researchr.org/home/scam-2025">SCAM 2025</a>.
 	    </p>
 	    <strong><a id="Charter"></a>Steering Committee</strong>
 	    <ul class="entrylist">
-			<li><a href="http://www.inf.u-szeged.hu/~beszedes/eng/index.html" target="_blank">Árpád Beszédes</a>, 2021-2024, 2nd term, <b>SC Chair</b></li>
-			<li><a href="https://benhermann.eu/" target="_blank">Ben Hermann</a>, 2021-2024, 1st term</li>
+			<li><a href="https://leonmoonen.com/" target="_blank">Leon Moonen</a>, 2023-2026, 1st term, <b>SC Chair</b></li>
 			<li><a href="https://profs.scienze.univr.it/~ceccato/" target="_blank">Mariano Ceccato</a>, 2022-2025, 1st term</li>
 			<li><a href="https://www.johanfabry.be" target="_blank">Johan Fabry</a>, 2022-2025, 2nd term</li>
-			<li><a href="https://leonmoonen.com/" target="_blank">Leon Moonen</a>, 2023-2026, 1st term</li>
 			<li><a href="https://software.imdea.org/~alessandra.gorla/" target="_blank">Alessandra Gorla</a>, 2023-2026, 1st term</li>
+			<li><a href="https://ise.usask.ca/team/" target="_blank">Banani Roy</a>, 2024-2027, 1st term</li>
+			<li><a href="https://soft.vub.ac.be/~cderoove/" target="_blank">Coen De Roover</a>, 2024-2027, 1st term</li>
 	    </ul>
 		
 	    <strong><a id="Charter"></a>Charter</strong>
@@ -55,6 +55,7 @@
 	    </p>
 	    <strong><a id="Conference"></a>Conference</strong>
 	    <ul class="entrylist">
+			<li><a href="https://conf.researchr.org/home/scam-2025">SCAM 2025</a>, Auckland, New Zealand, 7th-8th September 2025</li>
 			<li><a href="https://conf.researchr.org/home/scam-2024">SCAM 2024</a>, Flagstaff, AZ, USA, 7th-8th October 2024</li>
 			<li><a href="http://www.ieee-scam.org/2023">SCAM 2023</a>, Bogotá, Colombia, 2nd-3rd October 2023</li>
 			<li><a href="http://www.ieee-scam.org/2022">SCAM 2022</a>, Limassol, Cyprus, 3rd-4th October 2022</li>


### PR DESCRIPTION
The following PR introduces the following changes:

- Updates the list of the current Steering Committee members.
- Includes a link to SCAM25's researchr.org webpage.